### PR TITLE
Fix AUR source directory in GoReleaser config

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -279,10 +279,10 @@ aur_sources:
     depends:
       - glibc
     prepare: |-
-      cd "${pkgname}_${pkgver}"
+      cd "${srcdir}"
       go mod download
     build: |-
-      cd "${pkgname}_${pkgver}"
+      cd "${srcdir}"
       export CGO_CPPFLAGS="${CPPFLAGS}"
       export CGO_CFLAGS="${CFLAGS}"
       export CGO_CXXFLAGS="${CXXFLAGS}"
@@ -290,6 +290,6 @@ aur_sources:
       export GOFLAGS="-buildmode=pie -trimpath -mod=readonly -modcacherw"
       go build -ldflags="-w -s -buildid='' -linkmode=external -X fontget/internal/version.Version=${pkgver}" -o fontget .
     package: |-
-      cd "${pkgname}_${pkgver}"
+      cd "${srcdir}"
       install -Dm755 ./fontget "${pkgdir}/usr/bin/fontget"
     commit_msg_template: "Update to {{ .Tag }}"


### PR DESCRIPTION
## Summary
- update the AUR GoReleaser hooks to run from `${srcdir}`
- fixes the generated PKGBUILD when the release source tarball extracts directly into the makepkg source directory

## Verification
- Applied the equivalent PKGBUILD patch locally and ran `makepkg -f --cleanbuild --nodeps` successfully for `fontget 2.4.0-1`
- Verified the built binary reports `FontGet v2.4.0`