### PR TITLE
Defer machine font directory creation

### DIFF
--- a/internal/platform/darwin.go
+++ b/internal/platform/darwin.go
@@ -31,9 +31,6 @@ func NewFontManager() (FontManager, error) {
 
 	// System font directory
 	systemFontDir := "/Library/Fonts"
-	if err := ensureDir(systemFontDir); err != nil {
-		return nil, fmt.Errorf("failed to ensure system font directory exists: %w", err)
-	}
 
 	return &darwinFontManager{
 		userFontDir:   userFontDir,
@@ -71,6 +68,10 @@ func (m *darwinFontManager) InstallFont(fontPath string, scope InstallationScope
 		targetDir = m.systemFontDir
 	default:
 		return fmt.Errorf("invalid installation scope: %s", scope)
+	}
+
+	if err := ensureDir(targetDir); err != nil {
+		return fmt.Errorf("failed to ensure font directory exists: %w", err)
 	}
 
 	targetPath := filepath.Join(targetDir, fontName)

--- a/internal/platform/linux.go
+++ b/internal/platform/linux.go
@@ -30,9 +30,6 @@ func NewFontManager() (FontManager, error) {
 
 	// System font directory
 	systemFontDir := "/usr/local/share/fonts"
-	if err := ensureDir(systemFontDir); err != nil {
-		return nil, fmt.Errorf("failed to ensure system font directory exists: %w", err)
-	}
 
 	return &linuxFontManager{
 		userFontDir:   userFontDir,
@@ -70,6 +67,10 @@ func (m *linuxFontManager) InstallFont(fontPath string, scope InstallationScope,
 		targetDir = m.systemFontDir
 	default:
 		return fmt.Errorf("invalid installation scope: %s", scope)
+	}
+
+	if err := ensureDir(targetDir); err != nil {
+		return fmt.Errorf("failed to ensure font directory exists: %w", err)
 	}
 
 	targetPath := filepath.Join(targetDir, fontName)


### PR DESCRIPTION
## Summary
- stop Linux and macOS font manager initialization from creating machine font directories unconditionally
- create the selected target font directory lazily during install instead
- fixes user-scope installs failing when `/usr/local/share/fonts` or `/Library/Fonts` is not writable or does not exist

## Verification
- `go test ./internal/platform`
- `go run . install google.google-sans --scope user --accept-agreements --accept-defaults --debug`
  - confirmed the command used `/home/magni/.local/share/fonts`
  - installed 8 Google Sans variants successfully without requiring `/usr/local/share/fonts`